### PR TITLE
Update go module path declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # bybit-go-api
-[![GO 1.21.0](https://img.shields.io/badge/Go-1.21.0-brightgreen.svg)](https://github.com/wuhewuhe/bybit-go-api)   [![Contributor Victor](https://img.shields.io/badge/contributor-Victor-blue.svg)](https://github.com/wuhewuhe/bybit-go-api)   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/wuhewuhe/bybit-go-api/blob/main/LICENSE)
+[![GO 1.21.0](https://img.shields.io/badge/Go-1.21.0-brightgreen.svg)](https://github.com/bybit-exchange/bybit-go-api)   [![Contributor Victor](https://img.shields.io/badge/contributor-Victor-blue.svg)](https://github.com/bybit-exchange/bybit-go-api)   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/bybit-exchange/bybit-go-api/blob/main/LICENSE)
+
 ## Table of Contents
-- [About](#about)
-- [Development](#development)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Contact](#contact)
-- [Contributors](#contributors)
+- [bybit-go-api](#bybit-go-api)
+	- [Table of Contents](#table-of-contents)
+	- [About](#about)
+	- [Development](#development)
+	- [Installation](#installation)
+	- [Usage](#usage)
+		- [Rest API](#rest-api)
+		- [Websocket public channel](#websocket-public-channel)
+		- [Websocket private channel](#websocket-private-channel)
+	- [Contact](#contact)
+	- [Contributors](#contributors)
+
 ## About
 The Official Go Lang API connector for Bybit's HTTP and WebSocket APIs.
 
@@ -41,10 +48,11 @@ require (
 ```
 
 To import my package you need just to put the link to your go mode file
-**github.com/wuhewuhe/bybit.go.api**
+**github.com/bybit-exchange/bybit.go.api**
 
 ## Usage
 Note: Replace placeholders (like YOUR_API_KEY, links, or other details) with the actual information. You can also customize this template to better fit the actual state and details of your Java API.
+
 ### Rest API
 - Place an order by Map
 ```go
@@ -166,13 +174,13 @@ List of other contributors
         <a href="https://github.com/wuhewuhe">
             <img src="https://avatars.githubusercontent.com/u/32245754?v=4" width="100px;" alt=""/>
             <br />
-            <sub>   
+            <sub>
                 <b>Victor</b>
             </sub>
         </a>
         <br />
-        <a href="https://github.com/wuhewuhe/bybit-java-api/commits?author=wuhewuhe" title="Code">💻</a>
-        <a href="https://github.com/wuhewuhe/bybit-java-api/commits?author=wuhewuhe" title="Documentation">📖</a>
+        <a href="https://github.com/bybit-exchange/bybit-java-api/commits?author=wuhewuhe" title="Code">💻</a>
+        <a href="https://github.com/bybit-exchange/bybit-java-api/commits?author=wuhewuhe" title="Documentation">📖</a>
     </td>
   </tr>
 </table>

--- a/account.go
+++ b/account.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type AccountClient struct {

--- a/asset.go
+++ b/asset.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type AssetClient struct {

--- a/broker.go
+++ b/broker.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type BrokerServiceClient struct {

--- a/bybit_api_client.go
+++ b/bybit_api_client.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/bitly/go-simplejson"
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/examples/Account/get_transaction.go
+++ b/examples/Account/get_transaction.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	bybit "github.com/wuhewuhe/bybit.go.api"
+
+	bybit "github.com/bybit-exchange/bybit.go.api"
 )
 
 func main() {

--- a/examples/Asset/get_coin_info.go
+++ b/examples/Asset/get_coin_info.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	bybit "github.com/wuhewuhe/bybit.go.api"
+
+	bybit "github.com/bybit-exchange/bybit.go.api"
 )
 
 func main() {

--- a/examples/Asset/get_transfer_coin.go
+++ b/examples/Asset/get_transfer_coin.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	bybit "github.com/wuhewuhe/bybit.go.api"
+
+	bybit "github.com/bybit-exchange/bybit.go.api"
 )
 
 func main() {

--- a/examples/Trade/place_batch_trade.go
+++ b/examples/Trade/place_batch_trade.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	bybit "github.com/wuhewuhe/bybit.go.api"
+
+	bybit "github.com/bybit-exchange/bybit.go.api"
 )
 
 func main() {

--- a/examples/Trade/place_order.go
+++ b/examples/Trade/place_order.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	bybit "github.com/wuhewuhe/bybit.go.api"
+
+	bybit "github.com/bybit-exchange/bybit.go.api"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wuhewuhe/bybit.go.api
+module github.com/bybit-exchange/bybit.go.api
 
 go 1.21
 

--- a/lending.go
+++ b/lending.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type LendingServiceClient struct {

--- a/market_service.go
+++ b/market_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wuhewuhe/bybit.go.api/models"
+	"github.com/bybit-exchange/bybit.go.api/models"
 )
 
 // MarketKlinesService Market Kline (GET /v5/market/kline)

--- a/market_service_test.go
+++ b/market_service_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/bybit-exchange/bybit.go.api/models"
 	"github.com/stretchr/testify/suite"
-	"github.com/wuhewuhe/bybit.go.api/models"
 )
 
 type marketTestSuite struct {

--- a/position.go
+++ b/position.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type PositionClient struct {

--- a/pre_upgrade.go
+++ b/pre_upgrade.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type PreUpgradeClient struct {

--- a/spot_leverage.go
+++ b/spot_leverage.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type SpotLeverageClient struct {

--- a/spot_margin.go
+++ b/spot_margin.go
@@ -3,8 +3,9 @@ package bybit_connector
 import (
 	"context"
 	"errors"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type SpotMarginClient struct {

--- a/trade.go
+++ b/trade.go
@@ -2,9 +2,10 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
-	"github.com/wuhewuhe/bybit.go.api/models"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
+	"github.com/bybit-exchange/bybit.go.api/models"
 )
 
 type TradeClient struct {

--- a/user.go
+++ b/user.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/bybit-exchange/bybit.go.api/handlers"
 )
 
 type UserServiceClient struct {


### PR DESCRIPTION

```sh
➜ go get github.com/bybit-exchange/bybit.go.api
go: downloading github.com/bybit-exchange/bybit.go.api v0.0.0-20240222172100-8a4f616e98e4
go: github.com/bybit-exchange/bybit.go.api@upgrade (v0.0.0-20240222172100-8a4f616e98e4) requires github.com/bybit-exchange/bybit.go.api@v0.0.0-20240222172100-8a4f616e98e4: parsing go.mod:
	module declares its path as: github.com/wuhewuhe/bybit.go.api
	        but was required as: github.com/bybit-exchange/bybit.go.api
```