### PR TITLE
Fix GetAccountInfo underlying URI

### DIFF
--- a/account.go
+++ b/account.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/wuhewuhe/bybit.go.api/handlers"
 )
 
 type AccountClient struct {
@@ -146,7 +147,7 @@ func (s *AccountClient) GetCollateralInfo(ctx context.Context, opts ...RequestOp
 func (s *AccountClient) GetAccountInfo(ctx context.Context, opts ...RequestOption) (res *ServerResponse, err error) {
 	r := &request{
 		method:   http.MethodGet,
-		endpoint: "/v5/account/upgrade-to-uta",
+		endpoint: "/v5/account/info",
 		secType:  secTypeSigned,
 	}
 	data, err := s.c.callAPI(ctx, r, opts...)


### PR DESCRIPTION
It seems to be the `GetAccountInfo` requests the wrong URI, the same as for the `UpgradeToUTA` method