### PR TITLE
should check error of SendRequest

### DIFF
--- a/account.go
+++ b/account.go
@@ -21,7 +21,10 @@ func (s *BybitClientRequest) GetTransactionLog(ctx context.Context, opts ...Requ
 		endpoint: endpoint,
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -34,7 +37,10 @@ func (s *BybitClientRequest) GetFeeRates(ctx context.Context, opts ...RequestOpt
 		endpoint: "/v5/account/fee-rate",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -47,7 +53,10 @@ func (s *BybitClientRequest) GetAccountWallet(ctx context.Context, opts ...Reque
 		endpoint: "/v5/account/wallet-balance",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -60,7 +69,10 @@ func (s *BybitClientRequest) GetBorrowHistory(ctx context.Context, opts ...Reque
 		endpoint: "/v5/account/borrow-history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -73,7 +85,10 @@ func (s *BybitClientRequest) GetCoinGreeks(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/asset/coin-greeks",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -86,7 +101,10 @@ func (s *BybitClientRequest) GetCollateralInfo(ctx context.Context, opts ...Requ
 		endpoint: "/v5/account/collateral-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -96,7 +114,10 @@ func (s *BybitClientRequest) GetAccountInfo(ctx context.Context, opts ...Request
 		endpoint: "/v5/account/info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -106,7 +127,10 @@ func (s *BybitClientRequest) GetMMPState(ctx context.Context, opts ...RequestOpt
 		endpoint: "/v5/account/mmp-state",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -116,7 +140,10 @@ func (s *BybitClientRequest) SetSpotHedgeMode(ctx context.Context, opts ...Reque
 		endpoint: "/v5/account/set-hedging-mode",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -126,7 +153,10 @@ func (s *BybitClientRequest) UpgradeToUTA(ctx context.Context, opts ...RequestOp
 		endpoint: "/v5/account/upgrade-to-uta",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -136,7 +166,10 @@ func (s *BybitClientRequest) SetCollateralCoin(ctx context.Context, opts ...Requ
 		endpoint: "/v5/account/set-collateral-switch",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -146,7 +179,10 @@ func (s *BybitClientRequest) SetMarginMode(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/account/set-margin-mode",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -156,7 +192,10 @@ func (s *BybitClientRequest) SetMarketMakerProtection(ctx context.Context, opts 
 		endpoint: "/v5/account/mmp-modify",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -166,7 +205,10 @@ func (s *BybitClientRequest) ResetMarketMakerProtection(ctx context.Context, opt
 		endpoint: "/v5/account/mmp-reset",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -176,7 +218,10 @@ func (s *BybitClientRequest) GetDisconnectProtectionInfo(ctx context.Context, op
 		endpoint: "/v5/account/query-dcp-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -186,6 +231,9 @@ func (s *BybitClientRequest) GetSelfMarketProtectionGroup(ctx context.Context, o
 		endpoint: "/v5/account/smp-group",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/asset.go
+++ b/asset.go
@@ -2,8 +2,9 @@ package bybit_connector
 
 import (
 	"context"
-	"github.com/wuhewuhe/bybit.go.api/handlers"
 	"net/http"
+
+	"github.com/wuhewuhe/bybit.go.api/handlers"
 )
 
 func (s *BybitClientRequest) GetAssetOrderRecord(ctx context.Context, opts ...RequestOption) (res *ServerResponse, err error) {
@@ -12,7 +13,10 @@ func (s *BybitClientRequest) GetAssetOrderRecord(ctx context.Context, opts ...Re
 		endpoint: "/v5/asset/exchange/order-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -22,7 +26,10 @@ func (s *BybitClientRequest) GetAssetInfo(ctx context.Context, opts ...RequestOp
 		endpoint: "/v5/asset/transfer/query-asset-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -32,7 +39,10 @@ func (s *BybitClientRequest) GetDeliveryRecord(ctx context.Context, opts ...Requ
 		endpoint: "/v5/asset/delivery-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -42,7 +52,10 @@ func (s *BybitClientRequest) GetUsdcSettlement(ctx context.Context, opts ...Requ
 		endpoint: "/v5/asset/settlement-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -52,7 +65,10 @@ func (s *BybitClientRequest) GetAllCoinsBalance(ctx context.Context, opts ...Req
 		endpoint: "/v5/asset/transfer/query-account-coins-balance",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -65,7 +81,10 @@ func (s *BybitClientRequest) GetSingleCoinsBalance(ctx context.Context, opts ...
 		endpoint: "/v5/asset/transfer/query-account-coin-balance",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -78,7 +97,10 @@ func (s *BybitClientRequest) GetTransferableCoin(ctx context.Context, opts ...Re
 		endpoint: "/v5/asset/transfer/query-transfer-coin-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -91,7 +113,10 @@ func (s *BybitClientRequest) CreateInternalTransfer(ctx context.Context, opts ..
 		endpoint: "/v5/asset/transfer/inter-transfer",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -104,7 +129,10 @@ func (s *BybitClientRequest) CreateUniversalTransfer(ctx context.Context, opts .
 		endpoint: "/v5/asset/transfer/universal-transfer",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -117,7 +145,10 @@ func (s *BybitClientRequest) SetDepositAccount(ctx context.Context, opts ...Requ
 		endpoint: "/v5/asset/deposit/deposit-to-account",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -130,7 +161,10 @@ func (s *BybitClientRequest) CreateWithdraw(ctx context.Context, opts ...Request
 		endpoint: "/v5/asset/withdraw/create",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -143,7 +177,10 @@ func (s *BybitClientRequest) CancelWithdraw(ctx context.Context, opts ...Request
 		endpoint: "/v5/asset/withdraw/cancel",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -156,7 +193,10 @@ func (s *BybitClientRequest) GetInternalTransferRecords(ctx context.Context, opt
 		endpoint: "/v5/asset/transfer/query-inter-transfer-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -166,7 +206,10 @@ func (s *BybitClientRequest) GetUniversalTransferRecords(ctx context.Context, op
 		endpoint: "/v5/asset/transfer/query-universal-transfer-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -176,7 +219,10 @@ func (s *BybitClientRequest) GetSubAccUids(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/asset/transfer/query-sub-member-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -186,7 +232,10 @@ func (s *BybitClientRequest) GetAllowedDepositCoin(ctx context.Context, opts ...
 		endpoint: "/v5/asset/deposit/query-allowed-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -196,7 +245,10 @@ func (s *BybitClientRequest) GetDepositRecords(ctx context.Context, opts ...Requ
 		endpoint: "/v5/asset/deposit/query-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -206,7 +258,10 @@ func (s *BybitClientRequest) GetSubMemberDepositRecords(ctx context.Context, opt
 		endpoint: "/v5/asset/deposit/query-sub-member-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -216,7 +271,10 @@ func (s *BybitClientRequest) GetInternalDepositRecords(ctx context.Context, opts
 		endpoint: "/v5/asset/deposit/query-internal-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -226,7 +284,10 @@ func (s *BybitClientRequest) GetMasterAccDepositAddress(ctx context.Context, opt
 		endpoint: "/v5/asset/deposit/query-address",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -236,7 +297,10 @@ func (s *BybitClientRequest) GetSubAccDepositAddress(ctx context.Context, opts .
 		endpoint: "/v5/asset/deposit/query-sub-member-address",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -246,7 +310,10 @@ func (s *BybitClientRequest) GetCoinInfo(ctx context.Context, opts ...RequestOpt
 		endpoint: "/v5/asset/coin/query-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -256,7 +323,10 @@ func (s *BybitClientRequest) GetWithdrawalAmount(ctx context.Context, opts ...Re
 		endpoint: "/v5/asset/withdraw/withdrawable-amount",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -266,7 +336,10 @@ func (s *BybitClientRequest) GetWithdrawalRecords(ctx context.Context, opts ...R
 		endpoint: "/v5/asset/withdraw/query-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -276,7 +349,10 @@ func (s *BybitClientRequest) GetConvertCoinList(ctx context.Context, opts ...Req
 		endpoint: "/v5/asset/exchange/query-coin-list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -286,7 +362,10 @@ func (s *BybitClientRequest) GetConvertStatus(ctx context.Context, opts ...Reque
 		endpoint: "/v5/asset/exchange/convert-result-query",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -296,7 +375,10 @@ func (s *BybitClientRequest) GetConvertHistory(ctx context.Context, opts ...Requ
 		endpoint: "/v5/asset/exchange/query-convert-history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -306,7 +388,10 @@ func (s *BybitClientRequest) RequestConvertQuote(ctx context.Context, opts ...Re
 		endpoint: "/v5/asset/exchange/quote-apply",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -316,6 +401,9 @@ func (s *BybitClientRequest) ConfirmConvertQuote(ctx context.Context, opts ...Re
 		endpoint: "/v5/asset/exchange/convert-execute",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/broker.go
+++ b/broker.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) GetBrokerEarning(ctx context.Context, opts ...Reque
 		endpoint: "/v5/broker/earnings-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) GetBrokerAccountInfo(ctx context.Context, opts ...R
 		endpoint: "/v5/broker/account-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,6 +47,9 @@ func (s *BybitClientRequest) GetAllSubMembersDepositRecords(ctx context.Context,
 		endpoint: "/v5/broker/asset/query-sub-member-deposit-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/bybit_api_client.go
+++ b/bybit_api_client.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/wuhewuhe/bybit.go.api/models"
 	"io"
 	"log"
 	"net/http"
@@ -18,7 +17,9 @@ import (
 
 	"github.com/bitly/go-simplejson"
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/wuhewuhe/bybit.go.api/handlers"
+	"github.com/wuhewuhe/bybit.go.api/models"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -37,10 +38,10 @@ type ServerResponse struct {
 	Time       int64       `json:"time"`
 }
 
-func SendRequest(ctx context.Context, opts []RequestOption, r *request, s *BybitClientRequest, err error) []byte {
+func SendRequest(ctx context.Context, opts []RequestOption, r *request, s *BybitClientRequest, err error) ([]byte, error) {
 	r.setParams(s.params)
 	data, err := s.c.callAPI(ctx, r, opts...)
-	return data
+	return data, err
 }
 
 func GetServerResponse(err error, data []byte) (*ServerResponse, error) {

--- a/lending.go
+++ b/lending.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) GetInsLoanInfo(ctx context.Context, opts ...Request
 		endpoint: "/v5/ins-loan/product-infos",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) GetInsMarginCoinInfo(ctx context.Context, opts ...R
 		endpoint: "/v5/ins-loan/ensure-tokens-convert",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,7 +47,10 @@ func (s *BybitClientRequest) GetInsLoanOrders(ctx context.Context, opts ...Reque
 		endpoint: "/v5/ins-loan/loan-order",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -54,7 +63,10 @@ func (s *BybitClientRequest) GetInsRepayOrders(ctx context.Context, opts ...Requ
 		endpoint: "/v5/ins-loan/repaid-history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -64,7 +76,10 @@ func (s *BybitClientRequest) GetInsLoanToValue(ctx context.Context, opts ...Requ
 		endpoint: "/v5/ins-loan/ltv-convert",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -74,7 +89,10 @@ func (s *BybitClientRequest) AssociateInsLoan(ctx context.Context, opts ...Reque
 		endpoint: "/v5/ins-loan/association-uid",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -88,7 +106,10 @@ func (s *BybitClientRequest) GetC2cLendingCoinInfo(ctx context.Context, opts ...
 		endpoint: "/v5/lending/info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -102,7 +123,10 @@ func (s *BybitClientRequest) GetC2cLendingOrders(ctx context.Context, opts ...Re
 		endpoint: "/v5/lending/history-order",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -116,7 +140,10 @@ func (s *BybitClientRequest) GetC2cLendingAccountInfo(ctx context.Context, opts 
 		endpoint: "/v5/lending/account",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -130,7 +157,10 @@ func (s *BybitClientRequest) C2cDepositFunds(ctx context.Context, opts ...Reques
 		endpoint: "/v5/lending/purchase",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -144,7 +174,10 @@ func (s *BybitClientRequest) C2cRedeemFunds(ctx context.Context, opts ...Request
 		endpoint: "/v5/lending/redeem",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -158,6 +191,9 @@ func (s *BybitClientRequest) C2cCancelRedeemFunds(ctx context.Context, opts ...R
 		endpoint: "/v5/lending/redeem-cancel",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/market_service.go
+++ b/market_service.go
@@ -14,7 +14,10 @@ func (s *BybitClientRequest) GetServerTime(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/market/time",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -24,7 +27,10 @@ func (s *BybitClientRequest) GetMarketKline(ctx context.Context, opts ...Request
 		endpoint: "/v5/market/kline",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -64,7 +70,10 @@ func (s *BybitClientRequest) GetMarkPriceKline(ctx context.Context, opts ...Requ
 		endpoint: "/v5/market/mark-price-kline",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -103,7 +112,10 @@ func (s *BybitClientRequest) GetIndexPriceKline(ctx context.Context, opts ...Req
 		endpoint: "/v5/market/mark-price-kline",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -142,7 +154,10 @@ func (s *BybitClientRequest) GetPremiumIndexPriceKline(ctx context.Context, opts
 		endpoint: "/v5/market/mark-price-kline",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -181,7 +196,10 @@ func (s *BybitClientRequest) GetInstrumentInfo(ctx context.Context, opts ...Requ
 		endpoint: "/v5/market/instruments-info",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -191,7 +209,10 @@ func (s *BybitClientRequest) GetOrderBookInfo(ctx context.Context, opts ...Reque
 		endpoint: "/v5/market/orderbook",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -201,7 +222,10 @@ func (s *BybitClientRequest) GetMarketTickers(ctx context.Context, opts ...Reque
 		endpoint: "/v5/market/tickers",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -211,7 +235,10 @@ func (s *BybitClientRequest) GetFundingRateHistory(ctx context.Context, opts ...
 		endpoint: "/v5/market/funding/history",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -221,7 +248,10 @@ func (s *BybitClientRequest) GetPublicRecentTrades(ctx context.Context, opts ...
 		endpoint: "/v5/market/recent-trade",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -231,7 +261,10 @@ func (s *BybitClientRequest) GetOpenInterests(ctx context.Context, opts ...Reque
 		endpoint: "/v5/market/open-interest",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -241,7 +274,10 @@ func (s *BybitClientRequest) GetHistoryVolatility(ctx context.Context, opts ...R
 		endpoint: "/v5/market/historical-volatility",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -251,7 +287,10 @@ func (s *BybitClientRequest) GetMarketInsurance(ctx context.Context, opts ...Req
 		endpoint: "/v5/market/insurance",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -261,7 +300,10 @@ func (s *BybitClientRequest) GetMarketRiskLimits(ctx context.Context, opts ...Re
 		endpoint: "/v5/market/risk-limit",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -271,7 +313,10 @@ func (s *BybitClientRequest) GetDeliveryPrice(ctx context.Context, opts ...Reque
 		endpoint: "/v5/market/delivery-price",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -281,6 +326,9 @@ func (s *BybitClientRequest) GetLongShortRatio(ctx context.Context, opts ...Requ
 		endpoint: "/v5/market/account-ratio",
 		secType:  secTypeNone,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/position.go
+++ b/position.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) GetPositionList(ctx context.Context, opts ...Reques
 		endpoint: "/v5/position/list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) SetPositionLeverage(ctx context.Context, opts ...Re
 		endpoint: "/v5/position/set-leverage",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,7 +47,10 @@ func (s *BybitClientRequest) SwitchPositionMargin(ctx context.Context, opts ...R
 		endpoint: "/v5/position/switch-isolated",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -56,7 +65,10 @@ func (s *BybitClientRequest) SetPositionTpslMode(ctx context.Context, opts ...Re
 		endpoint: "/v5/position/set-tpsl-mode",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -69,7 +81,10 @@ func (s *BybitClientRequest) SwitchPositionMode(ctx context.Context, opts ...Req
 		endpoint: "/v5/position/switch-mode",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -84,7 +99,10 @@ func (s *BybitClientRequest) SetPositionRiskLimit(ctx context.Context, opts ...R
 		endpoint: "/v5/position/set-risk-limit",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -97,7 +115,10 @@ func (s *BybitClientRequest) SetPositionTradingStop(ctx context.Context, opts ..
 		endpoint: "/v5/position/trading-stop",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -110,7 +131,10 @@ func (s *BybitClientRequest) SetPositionAutoMargin(ctx context.Context, opts ...
 		endpoint: "/v5/position/set-auto-add-margin",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -123,7 +147,10 @@ func (s *BybitClientRequest) UpdatePositionMargin(ctx context.Context, opts ...R
 		endpoint: "/v5/position/add-margin",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -136,7 +163,10 @@ func (s *BybitClientRequest) ConfirmPositionRiskLimit(ctx context.Context, opts 
 		endpoint: "/v5/position/confirm-pending-mmr",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -149,7 +179,10 @@ func (s *BybitClientRequest) MovePosition(ctx context.Context, opts ...RequestOp
 		endpoint: "/v5/position/move-positions",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -162,7 +195,10 @@ func (s *BybitClientRequest) GetMovePositionHistory(ctx context.Context, opts ..
 		endpoint: "/v5/position/move-history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -175,6 +211,9 @@ func (s *BybitClientRequest) GetClosePnl(ctx context.Context, opts ...RequestOpt
 		endpoint: "/v5/position/closed-pnl",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/pre_upgrade.go
+++ b/pre_upgrade.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) GetPreUpgradeOrderHistory(ctx context.Context, opts
 		endpoint: "/v5/pre-upgrade/order/history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) GetPreUpgradeTradeHistory(ctx context.Context, opts
 		endpoint: "/v5/pre-upgrade/execution/list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,7 +47,10 @@ func (s *BybitClientRequest) GetPreUpgradeClosedPnl(ctx context.Context, opts ..
 		endpoint: "/v5/pre-upgrade/position/closed-pnl",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -54,7 +63,10 @@ func (s *BybitClientRequest) GetPreUpgradeTransactionLog(ctx context.Context, op
 		endpoint: "/v5/pre-upgrade/account/transaction-log",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -67,7 +79,10 @@ func (s *BybitClientRequest) GetPreUpgradeOptionDeliveryRecord(ctx context.Conte
 		endpoint: "/v5/pre-upgrade/asset/delivery-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -80,6 +95,9 @@ func (s *BybitClientRequest) GetPreUpgradeUsdcSettlement(ctx context.Context, op
 		endpoint: "/v5/pre-upgrade/asset/settlement-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/spot_leverage.go
+++ b/spot_leverage.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) GetLeverageTokenInfo(ctx context.Context, opts ...R
 		endpoint: "/v5/spot-lever-token/info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) GetLeverageTokenOrders(ctx context.Context, opts ..
 		endpoint: "/v5/spot-lever-token/order-record",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,7 +47,10 @@ func (s *BybitClientRequest) GetLeverageTokenMarket(ctx context.Context, opts ..
 		endpoint: "/v5/spot-lever-token/reference",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -54,7 +63,10 @@ func (s *BybitClientRequest) PurchaseLeverageToken(ctx context.Context, opts ...
 		endpoint: "/v5/spot-lever-token/purchase",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -67,6 +79,9 @@ func (s *BybitClientRequest) RedeemLeverageToken(ctx context.Context, opts ...Re
 		endpoint: "/v5/spot-lever-token/redeem",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/spot_margin.go
+++ b/spot_margin.go
@@ -22,7 +22,10 @@ func (s *BybitClientRequest) GetSpotMarginData(ctx context.Context, opts ...Requ
 		endpoint: endpoint,
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -42,7 +45,10 @@ func (s *BybitClientRequest) GetSpotMarginInterests(ctx context.Context, opts ..
 		endpoint: endpoint,
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -137,7 +143,10 @@ func (s *BybitClientRequest) GetSpotMarginCoin(ctx context.Context, opts ...Requ
 		endpoint: "/v5/spot-cross-margin-trade/pledge-token",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -154,7 +163,10 @@ func (s *BybitClientRequest) GetSpotMarginBorrowCoin(ctx context.Context, opts .
 		endpoint: "/v5/spot-cross-margin-trade/borrow-token",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -171,7 +183,10 @@ func (s *BybitClientRequest) GetSpotMarginLoanAccountInfo(ctx context.Context, o
 		endpoint: "/v5/spot-cross-margin-trade/account",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -188,7 +203,10 @@ func (s *BybitClientRequest) GetSpotMarginBorrowOrders(ctx context.Context, opts
 		endpoint: "/v5/spot-cross-margin-trade/orders",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -205,7 +223,10 @@ func (s *BybitClientRequest) GetSpotMarginRepaymentOrders(ctx context.Context, o
 		endpoint: "/v5/spot-cross-margin-trade/repay-history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -222,7 +243,10 @@ func (s *BybitClientRequest) BorrowSpotMarginLoan(ctx context.Context, opts ...R
 		endpoint: "/v5/spot-cross-margin-trade/loan",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -239,6 +263,9 @@ func (s *BybitClientRequest) RepaySpotMarginLoan(ctx context.Context, opts ...Re
 		endpoint: "/v5/spot-cross-margin-trade/repay",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/trade.go
+++ b/trade.go
@@ -16,7 +16,10 @@ func (s *BybitClientRequest) PlaceOrder(ctx context.Context, opts ...RequestOpti
 		endpoint: "/v5/order/create",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -29,7 +32,10 @@ func (s *BybitClientRequest) AmendOrder(ctx context.Context, opts ...RequestOpti
 		endpoint: "/v5/order/amend",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -42,7 +48,10 @@ func (s *BybitClientRequest) CancelOrder(ctx context.Context, opts ...RequestOpt
 		endpoint: "/v5/order/cancel",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -55,7 +64,10 @@ func (s *BybitClientRequest) GetOpenOrders(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/order/realtime",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -68,7 +80,10 @@ func (s *BybitClientRequest) GetOrderHistory(ctx context.Context, opts ...Reques
 		endpoint: "/v5/order/history",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -81,7 +96,10 @@ func (s *BybitClientRequest) GetSpotBorrowQuota(ctx context.Context, opts ...Req
 		endpoint: "/v5/order/spot-borrow-check",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -94,7 +112,10 @@ func (s *BybitClientRequest) CancelAllOrders(ctx context.Context, opts ...Reques
 		endpoint: "/v5/order/cancel-all",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -107,7 +128,10 @@ func (s *BybitClientRequest) SetDisconnectCancelAll(ctx context.Context, opts ..
 		endpoint: "/v5/order/disconnected-cancel-all",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -120,7 +144,10 @@ func (s *BybitClientRequest) PlaceBatchOrder(ctx context.Context, opts ...Reques
 		endpoint: "/v5/order/create-batch",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetBatchOrderServerResponse(err, data)
 }
 
@@ -133,7 +160,10 @@ func (s *BybitClientRequest) AmendBatchOrder(ctx context.Context, opts ...Reques
 		endpoint: "/v5/order/amend-batch",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetBatchOrderServerResponse(err, data)
 }
 
@@ -146,7 +176,10 @@ func (s *BybitClientRequest) CancelBatchOrder(ctx context.Context, opts ...Reque
 		endpoint: "/v5/order/cancel-batch",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetBatchOrderServerResponse(err, data)
 }
 
@@ -159,7 +192,10 @@ func (s *BybitClientRequest) GetTradeHistory(ctx context.Context, opts ...Reques
 		endpoint: "/v5/execution/list",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -172,6 +208,9 @@ func (s *BybitClientRequest) RequestTestFund(ctx context.Context, opts ...Reques
 		endpoint: "/v5/account/demo-apply-money",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }

--- a/user.go
+++ b/user.go
@@ -15,7 +15,10 @@ func (s *BybitClientRequest) CreateSubMember(ctx context.Context, opts ...Reques
 		endpoint: "/v5/user/create-sub-member",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -28,7 +31,10 @@ func (s *BybitClientRequest) CreateSubApiKey(ctx context.Context, opts ...Reques
 		endpoint: "/v5/user/create-sub-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -41,7 +47,10 @@ func (s *BybitClientRequest) FreezeSubUID(ctx context.Context, opts ...RequestOp
 		endpoint: "/v5/user/frozen-sub-member",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -54,7 +63,10 @@ func (s *BybitClientRequest) ModifyMasterAPIKey(ctx context.Context, opts ...Req
 		endpoint: "/v5/user/update-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -67,7 +79,10 @@ func (s *BybitClientRequest) ModifySubAPIKey(ctx context.Context, opts ...Reques
 		endpoint: "/v5/user/update-sub-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -80,7 +95,10 @@ func (s *BybitClientRequest) DeleteSubUID(ctx context.Context, opts ...RequestOp
 		endpoint: "/v5/user/del-submember",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -93,7 +111,10 @@ func (s *BybitClientRequest) DeleteMasterAPIKey(ctx context.Context, opts ...Req
 		endpoint: "/v5/user/delete-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -106,7 +127,10 @@ func (s *BybitClientRequest) DeleteSubAPIKey(ctx context.Context, opts ...Reques
 		endpoint: "/v5/user/delete-sub-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -119,7 +143,10 @@ func (s *BybitClientRequest) GetSubUidList(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/user/query-sub-members",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -132,7 +159,10 @@ func (s *BybitClientRequest) GetSubUidListUnlimited(ctx context.Context, opts ..
 		endpoint: "/v5/user/submembers",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -142,7 +172,10 @@ func (s *BybitClientRequest) GetAPIKeyInfo(ctx context.Context, opts ...RequestO
 		endpoint: "/v5/user/query-api",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -155,7 +188,10 @@ func (s *BybitClientRequest) GetUidWalletType(ctx context.Context, opts ...Reque
 		endpoint: "/v5/user/get-member-type",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }
 
@@ -168,6 +204,9 @@ func (s *BybitClientRequest) GetAffiliateUserInfo(ctx context.Context, opts ...R
 		endpoint: "/v5/user/aff-customer-info",
 		secType:  secTypeSigned,
 	}
-	data := SendRequest(ctx, opts, r, s, err)
+	data, err := SendRequest(ctx, opts, r, s, err)
+	if err != nil {
+		return nil, err
+	}
 	return GetServerResponse(err, data)
 }


### PR DESCRIPTION
When cannot connect to bybit server, the sdk throws an unreadable error that json.Unmarshal meets an empty []byte, because there is no error check of SendRequest.