### PR TITLE
Docs: Fixed incorrect WebSocket example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,18 @@ fmt.Println(bybit.PrettyPrint(accountResult))
 
 ### Websocket public channel
 - Order book Subscribe
+
 ```go
 ws := bybit.NewBybitPublicWebSocket("wss://stream.bybit.com/v5/public/spot", func(message string) error {
 fmt.Println("Received:", message)
 return nil
 })
-_ = ws.Connect([]string{"orderbook.1.BTCUSDT"})
+_ = ws.Connect()
+_, err := ws.SendSubscription([]string{"orderbook.1.BTCUSDT"})
+if err != nil {
+	fmt.Println(err)
+	return nil
+}
 select {}
 ```
 
@@ -152,7 +158,12 @@ ws := bybit.NewBybitPrivateWebSocket("wss://stream-testnet.bybit.com/v5/private"
 	fmt.Println("Received:", message)
 	return nil
 })
-_ = ws.Connect([]string{"order"})
+_ = ws.Connect()
+_, err := ws.SendSubscription([]string{"order"})
+if err != nil {
+	fmt.Println(err)
+	return nil
+}
 select {}
 ```
 


### PR DESCRIPTION
### Description

This PR updates the WebSocket example code in the `README` for both public and private channels.

### Changes

- Updated the public WebSocket example to use `Connect()` followed by `SendSubscription(...)` with proper error handling.
- Updated the private WebSocket example similarly for the `"order"` topic.
- Improved clarity and correctness of the usage example.

### Reason

The previous examples used `Connect()` with a direct parameter, which is no longer correct or supported by the SDK. This update reflects the correct usage pattern with subscription and error handling.

### Checklist

- [x] Updated README examples
- [x] Verified the new example code compiles and runs as expected
- [ ] (Optional) Add a test or snippet if needed
