### PR TITLE
fix: WalletBalanceInfo.List should use WalletAccountInfo instead of AccountInfo

### DIFF
--- a/models/accountResponse.go
+++ b/models/accountResponse.go
@@ -37,7 +37,7 @@ type UnifiedUpdateMsg struct {
 }
 
 type WalletBalanceInfo struct {
-	List []AccountInfo `json:"list"`
+	List []WalletAccountInfo `json:"list"`
 }
 
 type WalletAccountInfo struct {


### PR DESCRIPTION
## Problem

`WalletBalanceInfo.List` is typed as `[]AccountInfo`, but the `/v5/account/wallet-balance` API endpoint returns objects that match `WalletAccountInfo`.

`AccountInfo` is the response model for `/v5/account/info` and only contains:
- `unifiedMarginStatus`, `marginMode`, `dcpStatus`, `timeWindow`, `smpGroup`, `isMasterTrader`, `updatedTime`

The wallet balance response contains fields like `totalEquity`, `totalWalletBalance`, `totalAvailableBalance`, `coin[]`, etc. — all of which are defined in `WalletAccountInfo` (line 43-56 in the same file).

## Impact

When users unmarshal the API response into `WalletBalanceInfo`, all balance-related fields are silently dropped because `AccountInfo` has no matching JSON tags for them. This results in **zero values** for all balance fields.

## Fix

One-line change: `WalletBalanceInfo.List` type from `[]AccountInfo` → `[]WalletAccountInfo`.

```diff
 type WalletBalanceInfo struct {
-	List []AccountInfo `json:"list"`
+	List []WalletAccountInfo `json:"list"`
 }
```

## Verification

Compared with the [official API documentation](https://bybit-exchange.github.io/docs/v5/account/wallet-balance) — the response `result.list[]` fields (`accountType`, `totalEquity`, `totalWalletBalance`, `coin[]`, etc.) exactly match `WalletAccountInfo`, not `AccountInfo`.