### PR TITLE
bybit_connector: log dropped error

### DIFF
--- a/bybit_websocket.go
+++ b/bybit_websocket.go
@@ -124,10 +124,13 @@ func (b *WebSocket) Connect() *WebSocket {
 		wssUrl += "?max_alive_time=" + b.maxAliveTime
 	}
 	b.conn, _, err = websocket.DefaultDialer.Dial(wssUrl, nil)
-
+	if err != nil {
+		fmt.Printf("connect to %q error: %s\n", wssUrl, err)
+		return nil
+	}
 	if b.requiresAuthentication() {
 		if err = b.sendAuth(); err != nil {
-			fmt.Println("Failed Connection:", fmt.Sprintf("%v", err))
+			fmt.Println("failed authentication:", fmt.Sprintf("%v", err))
 			return nil
 		}
 	}


### PR DESCRIPTION
This changes `WebSocket.Connect()` to pick up and log connection errors that were previously discarded. It also changes the logging around failed auth to reflect an authentication error, not a connection error.