### PR TITLE
error check after Dial

### DIFF
--- a/bybit_websocket.go
+++ b/bybit_websocket.go
@@ -124,6 +124,10 @@ func (b *WebSocket) Connect() *WebSocket {
 		wssUrl += "?max_alive_time=" + b.maxAliveTime
 	}
 	b.conn, _, err = websocket.DefaultDialer.Dial(wssUrl, nil)
+	if err != nil {
+		fmt.Println("Failed Connection:", fmt.Sprintf("%v", err))
+		return nil
+	}
 
 	if b.requiresAuthentication() {
 		if err = b.sendAuth(); err != nil {


### PR DESCRIPTION
Problem: WebSocket.Connect() does not check the Dial error for public WebSocket connections. The err from websocket.DefaultDialer.Dial() is only checked inside if b.requiresAuthentication() — which is false for public endpoints. When the dial fails, b.conn remains nil, but the method still sets b.isConnected = true and spawns handleIncomingMessages, monitorConnection, and ping goroutines. The first call to b.conn.ReadMessage() in handleIncomingMessages causes a nil pointer dereference panic, crashing the entire application.

Fix: Move the error check immediately after Dial, before any authentication logic, so it applies to both public and private WebSocket connections. If Dial fails, log the error and return nil — no goroutines are spawned, preventing the panic.

Lines changed: Connect() method in bybit_websocket.go — added 4 lines after websocket.DefaultDialer.Dial() call to check err != nil.