### PR TITLE
docs: fix outdated WebSocket example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ ws := bybit.NewBybitPublicWebSocket("wss://stream.bybit.com/v5/public/spot", fun
 fmt.Println("Received:", message)
 return nil
 })
-_ = ws.Connect([]string{"orderbook.1.BTCUSDT"})
+_, _ = ws.Connect().SendSubscription([]string{"orderbook.1.BTCUSDT"})
 select {}
 ```
 
@@ -184,7 +184,7 @@ ws := bybit.NewBybitPrivateWebSocket("wss://stream-testnet.bybit.com/v5/private"
 	fmt.Println("Received:", message)
 	return nil
 })
-_ = ws.Connect([]string{"order"})
+_, _ = ws.Connect().SendSubscription([]string{"order"})
 select {}
 ```
 


### PR DESCRIPTION
## Summary
- Update the two README WebSocket subscription examples so they match the current SDK API — `Connect()` no longer takes subscription args; subscriptions go through `SendSubscription`.
- Adopt the method-chain style already used in `examples/Websocket/*/main.go` for consistency.

## Origin
Supersedes external PR #10 by @r0k1s-i (adapted to match the project's existing example style). #10 can be closed pointing here.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [ ] Visual review of the rendered README markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)