### PR TITLE
fix: use WalletAccountInfo for WalletBalanceInfo.List

### DIFF
--- a/models/accountResponse.go
+++ b/models/accountResponse.go
@@ -37,7 +37,7 @@ type UnifiedUpdateMsg struct {
 }
 
 type WalletBalanceInfo struct {
-	List []AccountInfo `json:"list"`
+	List []WalletAccountInfo `json:"list"`
 }
 
 type WalletAccountInfo struct {


### PR DESCRIPTION
## Summary
- \`/v5/account/wallet-balance\` returns entries with fields like \`accountType\`, \`totalEquity\`, \`coin[]\`, which match \`WalletAccountInfo\` — not \`AccountInfo\` (that struct is the shape for \`/v5/account/info\`, with \`unifiedMarginStatus\`, \`marginMode\`, etc.).
- Before this fix, decoding a real wallet-balance response into \`WalletBalanceInfo\` would silently zero out every meaningful field.

## Origin
Supersedes external PR #13 by @0xEmberZz. #13 can be closed pointing here.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [ ] Decode a real \`/v5/account/wallet-balance\` response into \`WalletBalanceInfo\` and confirm fields populate.

## Follow-up (not in this PR)
The Bybit V5 wallet-balance response includes 4 \`*ByMp\` fields on the account object and 3 newer coin fields (\`spotHedgingQty\`, \`colRes\`, \`spotBorrow\`) that this SDK does not yet model. Encoding/json ignores them silently — worth a separate PR to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)