### PR TITLE
fix(websocket): check Dial error before using connection

### DIFF
--- a/bybit_websocket.go
+++ b/bybit_websocket.go
@@ -124,10 +124,13 @@ func (b *WebSocket) Connect() *WebSocket {
 		wssUrl += "?max_alive_time=" + b.maxAliveTime
 	}
 	b.conn, _, err = websocket.DefaultDialer.Dial(wssUrl, nil)
-
+	if err != nil {
+		fmt.Printf("connect to %q error: %s\n", wssUrl, err)
+		return nil
+	}
 	if b.requiresAuthentication() {
 		if err = b.sendAuth(); err != nil {
-			fmt.Println("Failed Connection:", fmt.Sprintf("%v", err))
+			fmt.Println("failed authentication:", fmt.Sprintf("%v", err))
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary
- \`websocket.DefaultDialer.Dial\`'s error was previously discarded, so a failed handshake left \`b.conn\` as \`nil\` and the next operation on it (\`sendAuth\` → \`WriteMessage\`, or \`handleIncomingMessages\` → \`ReadMessage\`) panicked with a nil-pointer dereference.
- Log the target URL + error and return early so callers can detect the failure via the \`*WebSocket\` return being nil (consistent with the existing pattern in \`monitorConnection\`).
- Also disambiguate the auth-failure log from the dial-failure log — the two error sources previously shared the same misleading \"Failed Connection\" prefix.

## Origin
Supersedes external PRs #18 (@Igor-Gagarin) and #15 (@alrs) — same bug. #18's variant with URL context in the error message is used here. Both can be closed pointing to this PR.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [ ] Manual: call \`Connect()\` against an unreachable WebSocket URL and confirm (a) no panic, (b) error log includes the URL, (c) return value is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)